### PR TITLE
Add pricing and contact sections

### DIFF
--- a/nomnom/src/app/page.tsx
+++ b/nomnom/src/app/page.tsx
@@ -1,4 +1,6 @@
 import FeatureCard from '@/components/FeatureCard';
+import PricingCard from '@/components/PricingCard';
+import ContactForm from '@/components/ContactForm';
 
 export default function Home() {
   return (
@@ -6,7 +8,7 @@ export default function Home() {
       <section className="flex flex-col items-center text-center pt-20 pb-32 bg-gray-50">
         <h1 className="text-4xl sm:text-5xl font-bold max-w-2xl">Empower local restaurants to become local champions</h1>
         <p className="mt-6 max-w-xl text-gray-600">Streamline restaurant operation, make staff happy, and elevate guest experience. All in one platform.</p>
-        <a href="#demo" className="mt-8 bg-black text-white px-6 py-3 rounded-md text-sm">Book a demo</a>
+        <a href="#contact" className="mt-8 bg-black text-white px-6 py-3 rounded-md text-sm">Book a demo</a>
       </section>
 
       <section id="features" className="py-16 bg-white">
@@ -15,6 +17,32 @@ export default function Home() {
           <FeatureCard title="Online Ordering" description="Take orders online with ease" />
           <FeatureCard title="Analytics" description="Insights to grow your business" />
         </div>
+      </section>
+
+      <section id="pricing" className="py-16 bg-gray-50">
+        <h2 className="text-3xl font-bold text-center mb-10">Pricing</h2>
+        <div className="max-w-7xl mx-auto px-4 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          <PricingCard
+            title="Starter"
+            price="$29/mo"
+            features={["Basic analytics", "Email support", "1 location"]}
+          />
+          <PricingCard
+            title="Pro"
+            price="$59/mo"
+            features={["Advanced reports", "Priority support", "Up to 5 locations"]}
+          />
+          <PricingCard
+            title="Enterprise"
+            price="Contact us"
+            features={["All features", "Dedicated rep", "Unlimited locations"]}
+          />
+        </div>
+      </section>
+
+      <section id="contact" className="py-16 bg-white">
+        <h2 className="text-3xl font-bold text-center mb-10">Get in touch</h2>
+        <ContactForm />
       </section>
     </div>
   );

--- a/nomnom/src/components/ContactForm.tsx
+++ b/nomnom/src/components/ContactForm.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function ContactForm() {
+  return (
+    <form className="max-w-md mx-auto space-y-4">
+      <input
+        type="text"
+        placeholder="Name"
+        className="w-full border px-3 py-2 rounded"
+      />
+      <input
+        type="email"
+        placeholder="Email"
+        className="w-full border px-3 py-2 rounded"
+      />
+      <textarea
+        placeholder="Message"
+        className="w-full border px-3 py-2 rounded"
+        rows={4}
+      />
+      <button type="submit" className="bg-black text-white px-4 py-2 rounded-md">
+        Send Message
+      </button>
+    </form>
+  );
+}

--- a/nomnom/src/components/Header.tsx
+++ b/nomnom/src/components/Header.tsx
@@ -10,7 +10,7 @@ export default function Header() {
           <Link href="#pricing" className="hover:underline">Pricing</Link>
           <Link href="#contact" className="hover:underline">Contact</Link>
         </nav>
-        <Link href="#demo" className="bg-black text-white px-4 py-2 rounded-md text-sm">Book a demo</Link>
+        <Link href="#contact" className="bg-black text-white px-4 py-2 rounded-md text-sm">Book a demo</Link>
       </div>
     </header>
   );

--- a/nomnom/src/components/PricingCard.tsx
+++ b/nomnom/src/components/PricingCard.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface PricingCardProps {
+  title: string;
+  price: string;
+  features: string[];
+}
+
+export default function PricingCard({ title, price, features }: PricingCardProps) {
+  return (
+    <div className="p-6 rounded-lg shadow bg-white text-center flex flex-col">
+      <h3 className="text-xl font-semibold mb-2">{title}</h3>
+      <p className="text-3xl font-bold mb-4">{price}</p>
+      <ul className="space-y-2 flex-1">
+        {features.map((f) => (
+          <li key={f} className="text-sm text-gray-600">
+            {f}
+          </li>
+        ))}
+      </ul>
+      <button className="mt-6 bg-black text-white px-4 py-2 rounded-md text-sm">
+        Select Plan
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable `PricingCard` and `ContactForm` components
- extend the landing page with Pricing and Contact sections
- update navigation link to point to new contact section

## Testing
- `npx next lint` *(fails: could not install packages in container)*

------
https://chatgpt.com/codex/tasks/task_e_684743e1d260832cafdad8ca908445c2